### PR TITLE
Various changes to time limits, and mosdept report

### DIFF
--- a/wdl/tasks/hiphase.wdl
+++ b/wdl/tasks/hiphase.wdl
@@ -204,7 +204,7 @@ task hiphase {
     docker: "~{runtime_attributes.container_registry}/hiphase@sha256:47fe7d42aea6b1b2e6d3c7401bc35a184464c3f647473d0525c00f3c968b40ad"
     cpu: threads
     memory: mem_gb + " GB"
-    time_minutes: "90"
+    time_minutes: "180"
     disk: disk_size + " GB"
     disks: "local-disk " + disk_size + " HDD"
     preemptible: runtime_attributes.preemptible_tries

--- a/wdl/tasks/mosdepth.wdl
+++ b/wdl/tasks/mosdepth.wdl
@@ -83,7 +83,7 @@ task mosdepth {
     #My thresholds capture:
     cat << EOF > thresholdCoverage.py
     import sys, pandas as pd
-    df=pd.read_csv('~{out_prefix}.mosdepth.thresholds.bed.gz', sep='\t')
+    df=pd.read_csv('~{out_prefix}.thresholds.bed.gz', sep='\t')
     fiveX=(df["5X"].sum())/3200000000
     twentyX=(df["20X"].sum())/3200000000
     fiftyX=(df["50X"].sum())/3200000000

--- a/wdl/tasks/pbmm2.wdl
+++ b/wdl/tasks/pbmm2.wdl
@@ -164,11 +164,11 @@ task pbmm2_align_wgs {
     docker: "~{runtime_attributes.container_registry}/pbmm2@sha256:24218cb5cbc68d1fd64db14a9dc38263d3d931c74aca872c998d12ef43020ef0"
     cpu: threads
     memory: mem_gb + " GB"
-    time_minutes: "1440"
+    time_minutes: "2880"
     disk: disk_size + " GB"
     disks: "local-disk " + disk_size + " HDD"
     preemptible: runtime_attributes.preemptible_tries
-    maxRetries: runtime_attributes.max_retries
+    maxRetries: 0
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
   }

--- a/wdl/tasks/pbsv.wdl
+++ b/wdl/tasks/pbsv.wdl
@@ -128,7 +128,7 @@ task pbsv_call {
     Int? shard_index
     Array[String]? regions
 
-    Int mem_gb = if select_first([sample_count, 1]) > 3 then 96 else 64
+    Int mem_gb = if select_first([sample_count, 1]) > 3 then 96 else 72
 
     RuntimeAttributes runtime_attributes
   }

--- a/wdl/workflows/deepvariant/deepvariant.wdl
+++ b/wdl/workflows/deepvariant/deepvariant.wdl
@@ -586,7 +586,7 @@ task deepvariant_postprocess_variants {
     docker: docker_image
     cpu: threads
     memory: mem_gb + " GB"
-    time_minutes: "180"
+    time_minutes: "240"
     disk: disk_size + " GB"
     disks: "local-disk " + disk_size + " HDD"
     preemptible: runtime_attributes.preemptible_tries


### PR DESCRIPTION
Increased some time limits related to hiphase, pbmm2 and deepvariant. I've also increased minimum memory allocation for deepvariant, and fixed a bug with my previously added mosdepth report. 